### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/wildland/ember-authenticate-me",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This will allow npmjs.org to get the correct repo URL for this package. (Right now it's pulling out the first Github URL from the README and presenting that as this package's repo URL.)