### PR TITLE
Fixes session lifecycle callbacks to run in call-loop and correctly grab session

### DIFF
--- a/addon/mixins/routes/authenticated.js
+++ b/addon/mixins/routes/authenticated.js
@@ -5,8 +5,8 @@ export function isAuthenticated(session, sessionLifecycle) {
 
   return new Ember.RSVP.Promise(function(resolve, reject) {
     if (!authenticated) {
-      session.fetch().then((sessionContent) => {
-        sessionLifecycle.userLoggedIn(sessionContent);
+      session.fetch().then(() => {
+        sessionLifecycle.userLoggedIn(session);
         resolve(...arguments);
       }).catch((e) => {
         reject(e);

--- a/addon/services/session-lifecycle.js
+++ b/addon/services/session-lifecycle.js
@@ -7,13 +7,17 @@ export default Ember.Service.extend({
   userLoggedIn(session) {
     const loginCallbacks = this.get('_loginCallbacks');
 
-    loginCallbacks.forEach(func => func(session));
+    Ember.run(() => {
+      loginCallbacks.forEach(func => Ember.run.next(null, () => func(session)));
+    });
   },
 
   userLoggedOut(session) {
     const logoutCallbacks = this.get('_logoutCallbacks');
 
-    logoutCallbacks.forEach(func => func(session));
+    Ember.run(() => {
+      logoutCallbacks.forEach(func => Ember.run.next(null, () => func(session)));
+    });
   },
 
   registerLoginCallback(func) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-authenticate-me",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Previously, the session lifecycle callbacks were not async,
resulting in errors inside of them to break login/logout if the
application had invalid logic inside of the callbacks. This commit
places the callbacks inside of the run-loop so that they become
async. It also correctly grabs the session inside of the login
route before executing the callbacks.