### PR TITLE
Remove dev on addon to fix lint warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,6 @@ module.exports = {
   },
 
   isDevelopingAddon() {
-    return true;
+    return false;
   }
 };


### PR DESCRIPTION
Set developing addon to false to prevent linting warnings

---
name: PR Template
about: Help give PR reviewers context of user goals, work done, and what the work should accomplish.
---

### User Story
*A User Story is a description of an objective a person should be able to achieve, or a feature that a person should be able to utilize, when using a software application.*

As a user I would like to only see my project linting warnings and not the addon ones

### Acceptance Criteria
*Acceptance Criteria should state intent, but not a solution (e.g., “A manager can approve or disapprove an audit form” rather than “A manager can click an ‘Approve/Disapprove’ radio button to approve an audit form”).*

- [ ] No linting warnings from the addon appear in the used project

### Any Notes from the Developer

Put developer notes here...

### Fixes Issues

- Fixes #<number>, #<number>

### New PR Checklist

- [ ] Rebase before opening pr
